### PR TITLE
Add functionality for selecting a random insert, rather than going in order

### DIFF
--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -456,7 +456,7 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
                         return null;
                     }
 
-                    if (selectRandomInsert) // select a random insert if there are any and this map supports random inserts
+                    if (selectRandomInsert) // select a random insert if there are any and if this map supports random inserts
                     {
                         if (comp.SurvivorJobInserts != null && comp.SurvivorJobInserts.TryGetValue(job, out var randomInsertList))
                             spawnAsJob = _random.Pick(randomInsertList).Insert;

--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -407,8 +407,10 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
                 }
 
                 var spawnAsJob = job;
+                var selectRandomInsert = SelectedPlanetMap?.Comp.SelectRandomSurvivorInsert ?? false;
 
-                if (comp.SurvivorJobInserts != null && comp.SurvivorJobInserts.TryGetValue(job, out var insert))
+                // select an insert in order, reducing the slot of that insert
+                if (comp.SurvivorJobInserts != null && comp.SurvivorJobInserts.TryGetValue(job, out var insert) && !selectRandomInsert)
                 {
                     var insertSuccess = false;
 
@@ -452,6 +454,12 @@ public sealed class CMDistressSignalRuleSystem : GameRuleSystem<CMDistressSignal
                     {
                         stop = true;
                         return null;
+                    }
+
+                    if (selectRandomInsert) // select a random insert if there are any and this map supports random inserts
+                    {
+                        if (comp.SurvivorJobInserts != null && comp.SurvivorJobInserts.TryGetValue(job, out var randomInsertList))
+                            spawnAsJob = _random.Pick(randomInsertList).Insert;
                     }
 
                     comp.SurvivorJobs[i] = (survJob, amount - 1);

--- a/Content.Shared/_RMC14/Rules/RMCPlanetMapPrototypeComponent.cs
+++ b/Content.Shared/_RMC14/Rules/RMCPlanetMapPrototypeComponent.cs
@@ -39,4 +39,11 @@ public sealed partial class RMCPlanetMapPrototypeComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public Dictionary<ProtoId<JobPrototype>, ProtoId<JobPrototype>>? SurvivorJobOverrides;
+
+    /// <summary>
+    /// Instead of using the limits of the insert, this will select a random insert and use the base job's limit when true.
+    /// If it is false, it will use the job slots of the insert. See Chance's Claim.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool SelectRandomSurvivorInsert = true;
 }

--- a/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
+++ b/Resources/Prototypes/_RMC14/Entities/rmc_planets.yml
@@ -79,6 +79,7 @@
     map: /Maps/_RMC14/chances.yml
     camouflage: Classic
     announcement: "Pan-Pan. This is the commanding officer of the UNS Hanyut, UNMC FORECON. We are currently grounded on planet LV-522 in the immediate area of Chance's Claim. We are unable to contact the Hanyut and our dropships are unable to take off at this time. We are requesting assistance from any nearby vessels; this broadcast is set to repeat every 24 hours."
+    selectRandomSurvivorInsert: false
     survivorJobs:
     - RMCSurvivorCommandingOfficer: 1
     - RMCSurvivorForeconBase: 7


### PR DESCRIPTION
good for forecon, but not for other maps
makes it so you wont never get cargotechs/beach bums/etc if the other job's slot isnt full